### PR TITLE
Map::Tube::CLI: Enhanced user interface, for details see Changes file

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,20 @@
 Revision history for Map::Tube::CLI
 
+v0.85.0 Tue Jun 09 12:00:00 2026 (GWS)
+      - Updated README.
+      - Introduced short options (in additon to long options).
+      - Added option --version/-V.
+      - Added option --list_maps/-M.
+      - Added option --list_stations/-S.
+      - Added option --tabular/-t.
+      - Require Map::Tube::Exception 3.25.
+      - Minor code optimisations.
+      - Make some sortings Unicode-aware (if Unicode::Collate is available)
+      - Updated dependencies in Makefile.PL.
+      - Handle cases of non-printable characters in route listings slightly better.
+      - Added test case.
+      - Updated POD.
+
 0.84  Tue Mar 31 22:45:00 2026
       This release prepared by @GWS
       - Added support for new maps: Brussels, Chicago, Leipzig, Muenchen,

--- a/META.json
+++ b/META.json
@@ -1,0 +1,80 @@
+{
+   "abstract" : "Command Line Interface for Map::Tube::* map.",
+   "author" : [
+      "Mohammad Sajid Anwar <mohammad.anwar@yahoo.com>"
+   ],
+   "dynamic_config" : 1,
+   "generated_by" : "ExtUtils::MakeMaker version 7.78, CPAN::Meta::Converter version 2.150013",
+   "license" : [
+      "artistic_2"
+   ],
+   "meta-spec" : {
+      "url" : "http://search.cpan.org/perldoc?CPAN::Meta::Spec",
+      "version" : 2
+   },
+   "name" : "Map-Tube-CLI",
+   "no_index" : {
+      "directory" : [
+         "t",
+         "inc"
+      ]
+   },
+   "prereqs" : {
+      "build" : {
+         "requires" : {
+            "Capture::Tiny" : "0.28",
+            "Test::More" : "0"
+         }
+      },
+      "configure" : {
+         "requires" : {
+            "ExtUtils::MakeMaker" : "0"
+         }
+      },
+      "runtime" : {
+         "recommends" : {
+            "Unicode::Collate" : "0"
+         },
+         "requires" : {
+            "Carp" : "0",
+            "Encode::Locale" : "1.05",
+            "MIME::Base64" : "3.14",
+            "Map::Tube" : "4.10",
+            "Map::Tube::Exception" : "3.25",
+            "Module::Pluggable" : "5.1",
+            "Moo" : "2.000000",
+            "MooX::Options" : "4.023",
+            "Path::Tiny" : "0",
+            "Text::ASCIITable" : "0.22",
+            "Try::Tiny" : "0",
+            "Types::Standard" : "1.000005",
+            "namespace::autoclean" : "0.28",
+            "perl" : "5.014",
+            "utf8::all" : "0.024"
+         }
+      }
+   },
+   "provides" : {
+      "Map::Tube::CLI" : {
+         "file" : "lib/Map/Tube/CLI.pm",
+         "version" : "v0.850.0"
+      },
+      "Map::Tube::CLI::Option" : {
+         "file" : "lib/Map/Tube/CLI/Option.pm",
+         "version" : "v0.850.0"
+      }
+   },
+   "release_status" : "stable",
+   "resources" : {
+      "bugtracker" : {
+         "web" : "https://github.com/manwar/Map-Tube-CLI/issues"
+      },
+      "repository" : {
+         "type" : "git",
+         "url" : "https://github.com/manwar/Map-Tube-CLI.git",
+         "web" : "https://github.com/manwar/Map-Tube-CLI"
+      }
+   },
+   "version" : "v0.850.0",
+   "x_serialization_backend" : "JSON::PP version 4.18"
+}

--- a/META.yml
+++ b/META.yml
@@ -1,0 +1,50 @@
+---
+abstract: 'Command Line Interface for Map::Tube::* map.'
+author:
+  - 'Mohammad Sajid Anwar <mohammad.anwar@yahoo.com>'
+build_requires:
+  Capture::Tiny: '0.28'
+  Test::More: '0'
+configure_requires:
+  ExtUtils::MakeMaker: '0'
+dynamic_config: 1
+generated_by: 'ExtUtils::MakeMaker version 7.78, CPAN::Meta::Converter version 2.150013'
+license: artistic_2
+meta-spec:
+  url: http://module-build.sourceforge.net/META-spec-v1.4.html
+  version: '1.4'
+name: Map-Tube-CLI
+no_index:
+  directory:
+    - t
+    - inc
+provides:
+  Map::Tube::CLI:
+    file: lib/Map/Tube/CLI.pm
+    version: v0.850.0
+  Map::Tube::CLI::Option:
+    file: lib/Map/Tube/CLI/Option.pm
+    version: v0.850.0
+recommends:
+  Unicode::Collate: '0'
+requires:
+  Carp: '0'
+  Encode::Locale: '1.05'
+  MIME::Base64: '3.14'
+  Map::Tube: '4.10'
+  Map::Tube::Exception: '3.25'
+  Module::Pluggable: '5.1'
+  Moo: '2.000000'
+  MooX::Options: '4.023'
+  Path::Tiny: '0'
+  Text::ASCIITable: '0.22'
+  Try::Tiny: '0'
+  Types::Standard: '1.000005'
+  namespace::autoclean: '0.28'
+  perl: '5.014'
+  utf8::all: '0.024'
+resources:
+  bugtracker: https://github.com/manwar/Map-Tube-CLI/issues
+  repository: https://github.com/manwar/Map-Tube-CLI.git
+version: v0.850.0
+x_serialization_backend: 'CPAN::Meta::YAML version 0.020'

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -27,18 +27,26 @@ WriteMakefile(
         'Moo'                  => '2.000000',
         'namespace::autoclean' => '0.28',
         'MIME::Base64'         => '3.14',
-        'Map::Tube::Exception' => '3.24',
+        'Map::Tube::Exception' => '3.25',
         'Map::Tube'            => '4.10',
         'Carp'                 => 0,
         'Path::Tiny'           => 0,
         'Encode::Locale'       => '1.05',
         'Text::ASCIITable'     => '0.22',
+        'Try::Tiny'            => 0,
         'utf8::all'            => '0.024',
     },
     dist  => { COMPRESS => 'gzip -9f', SUFFIX => 'gz', },
     clean => { FILES => 'Map-Tube-CLI-*' },
     (eval { ExtUtils::MakeMaker->VERSION(6.46) } ? (META_MERGE => {
         'meta-spec' => { version => 2 },
+        prereqs => {
+            runtime => {
+                recommends => {
+                    'Unicode::Collate' => '0',
+                },
+            },
+        },
         provides    => {
             'Map::Tube::CLI' => {
                 file    => 'lib/Map/Tube/CLI.pm',

--- a/README
+++ b/README
@@ -1,15 +1,8 @@
 Map::Tube::CLI
 
-The README  is  used  to  introduce the module and provide instructions on how to
-install the module, any machine dependencies it may have (for example C compilers
-and installed libraries) and any other information that should be provided before
-the module is installed.
-
-A  README  file  is required for CPAN modules since CPAN extracts the README file
-from a module distribution so that people browsing the archive can use it to  get
-an  idea  of  the  module's  uses.  It  is usually a good idea to provide version
-information here so that people can decide whether fixes for the module are worth
-downloading.
+This module provides a simple command line interface  to the package consuming L<Map::Tube>.
+The distribution contains a script C<map-tube>, using package L<Map::Tube::CLI> for
+easy command line utilisation of Map::Tube.
 
 INSTALLATION
 

--- a/lib/Map/Tube/CLI.pm
+++ b/lib/Map/Tube/CLI.pm
@@ -1,7 +1,11 @@
 package Map::Tube::CLI;
 
-$Map::Tube::CLI::VERSION   = '0.84';
-$Map::Tube::CLI::AUTHORITY = 'cpan:MANWAR';
+use strict;
+use warnings;
+use version;
+
+our $VERSION   = qv('v0.850.0');
+our $AUTHORITY = 'cpan:MANWAR';
 
 =head1 NAME
 
@@ -9,7 +13,7 @@ Map::Tube::CLI - Command Line Interface for Map::Tube::* map.
 
 =head1 VERSION
 
-Version 0.84
+Version v0.850.0
 
 =cut
 
@@ -19,12 +23,13 @@ use Carp qw(croak);
 use Data::Dumper;
 use MIME::Base64;
 use Map::Tube::Utils qw(is_valid_color);
-use Map::Tube::Exception::MissingStationName;
-use Map::Tube::Exception::InvalidStationName;
+use Map::Tube::Exception::FoundUnsupportedMap;
 use Map::Tube::Exception::InvalidBackgroundColor;
 use Map::Tube::Exception::InvalidLineName;
+use Map::Tube::Exception::InvalidStationName;
+use Map::Tube::Exception::MissingStationName;
+use Map::Tube::Exception::MissingMapName;
 use Map::Tube::Exception::MissingSupportedMap;
-use Map::Tube::Exception::FoundUnsupportedMap;
 use Map::Tube::CLI::Option;
 use Module::Pluggable
     search_path => [ 'Map::Tube' ],
@@ -34,6 +39,7 @@ use Module::Pluggable
 
 use Path::Tiny;
 use Text::ASCIITable;
+use Try::Tiny;
 use Moo;
 use namespace::autoclean;
 use MooX::Options;
@@ -41,40 +47,43 @@ with 'Map::Tube::CLI::Option';
 
 =head1 DESCRIPTION
 
-It provides simple command line interface  to the package consuming L<Map::Tube>.
-The distribution contains a script C<map-tube>, using package L<Map::Tube::CLI>.
+This module provides a simple command line interface  to the package consuming L<Map::Tube>.
+The distribution also contains a script C<map-tube> for use at the command line which uses this package.
 
 =head1 SYNOPSIS
 
-You can list all command line options by giving C<-h> flag.
+You can list all command line options by giving the C<-h> flag.
 
     $ map-tube -h
-    USAGE: map-tube [-h] [long options...]
+    USAGE: map-tube [-h] [options...]
 
-        --map=String      Map name
-        --start=String    Start station name
-        --end=String      End station name
-        --preferred       Show preferred route
-        --generate_map    Generate map as image
-        --line=String     Line name for map
-        --bgcolor=String  Map background color
-        --line_mappings   Generate line mappings
-        --line_notes      Generate line notes
-        --list_lines      List lines
-        --force           Force unsupported map (map name becomes case
-                          sensitive)
-        --debug           Run in debug mode
+        -m --map=String      Map name
+        -s --start=String    Start station name
+        -e --end=String      End station name
+        -p --preferred       Show preferred route
+        -g --generate_map    Generate map as image
+        -l --line=String     Line name to map
+        -b --bgcolor=String  Map background color
+        --line_mappings      Generate line mappings as table
+        --line_notes         Generate line notes
+        -M --list_maps       List supported maps
+        -L --list_lines      List lines in given map
+        -S --list_stations   List stations in given map
+        -t --tabular         Show route as table (not as list)
+        -f --force           Force unsupported map (map name becomes case sensitive)
+        -D --debug           Run in debug mode
+        -V --version         Show version information
 
-        --usage           show a short help message
-        -h                show a compact help message
-        --help            show a long help message
-        --man             show the manual
+        --usage              show a short help message
+        -h                   show a compact help message
+        --help               show a long help message
+        --man                show the manual
 
 =head1 COMMON USAGES
 
 =head2 Shortest Route
 
-You can also ask for shortest route in London Tube Map as below:
+You can ask for the shortest route in the London Tube Map as below: (Under Windows use double quotes.)
 
     $ map-tube --map London --start 'Baker Street' --end 'Wembley Park'
 
@@ -82,9 +91,26 @@ You can also ask for shortest route in London Tube Map as below:
 
 =head2 Preferred Shortest Route
 
-Now request for preferred route as below:
+Now a request for the preferred route:
 
     $ map-tube --map London --start 'Baker Street' --end 'Euston Square' --preferred
+
+    Baker Street (Circle, Hammersmith & City, Metropolitan), Great Portland Street (Circle, Hammersmith & City, Metropolitan), Euston Square (Circle, Hammersmith & City, Metropolitan)
+
+=head2 Preferred Shortest Route in Tabular Form
+
+And a request for the preferred route displayed as a table: (This also shows the use of short options.)
+
+    $ map-tube -m London -s 'Baker Street' -e 'Euston Square' -p -t
+    Metro Map London: Route from Baker Street to Euston Square.
+
+    .--------------------------------------------------------------------.
+    | Station Name          | Lines                                      |
+    +-----------------------+--------------------------------------------+
+    | Baker Street          | Circle, Hammersmith and City, Metropolitan |
+    | Great Portland Street | Circle, Hammersmith and City, Metropolitan |
+    | Euston Square         | Circle, Hammersmith and City, Metropolitan |
+    '-----------------------+--------------------------------------------'
 
     Baker Street (Circle, Hammersmith & City, Metropolitan), Great Portland Street (Circle, Hammersmith & City, Metropolitan), Euston Square (Circle, Hammersmith & City, Metropolitan)
 
@@ -96,24 +122,24 @@ directory. (It will silently overwrite any pre-existing file of the same name.)
 
     $ map-tube --map Delhi --generate_map
 
-In case you want different background color to the map then you can try below:
+In case you want a different background color to the map then you can try this:
 
     $ map-tube --map Delhi --bgcolor gray --generate_map
 
 =head2 Generate Just a Line Map
 
-To generate a graphical representation of just a particular line map, follow
+To generate a graphical representation of just a particular line, follow
 the command below. This will generate a PNG file named after the line in your
 current working directory. (It will silently overwrite any pre-existing file
 of the same name.)
 
     $ map-tube --map London --line Bakerloo --generate_map
 
-In case you want different background color to the map then you can try below:
+In case you want a different background color to the map then you can try this:
 
     $ map-tube --map London --line DLR --bgcolor yellow --generate_map
 
-=head2 Generate Line Mappings
+=head2 Generate Line Mappings as a Table
 
     $ map-tube --map London --line Bakerloo --line_mappings
 
@@ -121,27 +147,51 @@ In case you want different background color to the map then you can try below:
 
     $ map-tube --map London --line Bakerloo --line_notes
 
-=head2 List lines for the given map
+=head2 List the Lines for the Given Map
 
     $ map-tube --map London --list_lines
 
+=head2 List the Stations for the Given Map
+
+    $ map-tube --map London --list_stations
+
+=head2 List all Supported Maps
+
+This will show you a list of all officially supported maps. It will also show you
+which of these maps are not currently installed on your machine.
+
+    $ map-tube --list_maps
+
+=head2 Using a Map that is Not Officially Supported
+
+It is also possible to use tube maps that are not officially supported, e.g.,
+privately created maps: (This is also helpful while developing a new map.)
+
+    $ map-tube --map 'Slippery Rock' --start 'College Park' --end 'Greyhound station' --force
+
 =head2 General Error
 
-If encountered  invalid  map  or  missing map i.e not installed, you get an error
+If encountering an invalid map or a missing map (i.e not installed), you get an error
 message like below:
 
     $ map-tube --map xYz --start 'Baker Street' --end 'Euston Square'
     ERROR: Unsupported Map [xYz].
+
+This will produce a similar message if you do not have the tube map of Kazan installed;
+if you do have it, it will notify you that the starting station does not exist in this map:
 
     $ map-tube --map Kazan --start 'Baker Street' --end 'Euston Square'
     ERROR: Missing Map [Kazan].
 
 =head1 SUPPORTED MAPS
 
-The command line parameter C<map> can take one of the following map names.  It is
-case insensitive i.e. 'London' and 'lOndOn' are the same.
+The command line parameter C<map> can take one of the following map names. It is
+case insensitive, i.e. 'London' and 'lOndOn' are the same.
+Use the C<--list_maps> option describe above to get an up-to-date version of this list.
+Use the C<--force> option described above to use locally installed maps that are not on
+that list.
 
-You could use L<Task::Map::Tube::Bundle> to install the supported maps.Please make
+You could use L<Task::Map::Tube::Bundle> to install the supported maps. Please make
 sure you have the latest maps when you install.
 
 =over 4
@@ -267,10 +317,12 @@ sub BUILD {
 
     my $plugins = [ plugins ];
     my $map = $self->{map};
-    foreach my $plugin (@$plugins) {
-        my $key = _map_key($plugin);
-        if (defined $key && (uc($map) eq $key)) {
-            $self->{maps}->{uc($key)} = $plugin->new;
+    if ($map) {
+        foreach my $plugin (@$plugins) {
+            my $key = _map_key($plugin);
+            if (defined $key && (uc($map) eq $key)) {
+                $self->{maps}->{uc($key)} = $plugin->new;
+            }
         }
     }
 
@@ -310,42 +362,70 @@ expect any parameter. Here is the code from the supplied C<map-tube> script.
 sub run {
     my ($self) = @_;
 
-    my $start   = $self->start;
-    my $end     = $self->end;
-    my $map     = $self->map;
-    my $line    = $self->line;
-    my $bgcolor = $self->bgcolor;
-    my $map_obj = $self->{maps}->{uc($map)};
+    my $map_obj = $self->map ? $self->{maps}->{uc($self->map)} : undef;
 
-    if ($self->preferred) {
-        print $map_obj->get_shortest_route($start, $end)->preferred, "\n";
+    # Handle these two options first because map name may not be present:
+    if ($self->version) {
+        print _prepare_version_info($map_obj, $self->map), "\n";
+        return;
     }
-    elsif ($self->generate_map) {
-        $map_obj->bgcolor($bgcolor) if defined $bgcolor;
-        my $image_file = _clean_path( ( $line // $map ) . '.png' );
-        my $image_data = $map_obj->as_image($line);
+    elsif ($self->list_maps) {
+        my $map_list = _prepare_map_list();
+        if ($self->tabular) {
+            my $map_table = Text::ASCIITable->new;
+            $map_table->setCols('Map Name','Description');
+            $map_table->addRow(@$_) for @$map_list;
+            print "Supported Metro Maps\n\n";
+            no warnings;
+            print $map_table;
+        } else {
+            no warnings;
+            print join(', ', @$_), "\n" for @$map_list;
+        }
+        return;
+    }
+
+    if ($self->generate_map) {
+        $map_obj->bgcolor($self->bgcolor) if defined $self->bgcolor;
+        my $image_file = _clean_path( ( $self->line // $self->map ) . '.png' );
+        my $image_data = $map_obj->as_image($self->line);
 
         open(my $IMAGE, '>', $image_file);
         binmode($IMAGE);
         print $IMAGE decode_base64($image_data);
         close($IMAGE);
     }
-    elsif ($self->line_mappings || $self->line_notes) {
-        my ($line_map_table, $line_map_notes) = _prepare_mapping_notes($map_obj, $line);
-
-        if ($self->line_mappings) {
-            print sprintf("\n=head1 DESCRIPTION\n\n%s Metro Map: %s Line.\n\n", $map, $line);
-            print $line_map_table;
-        }
-        if ($self->line_notes) {
-            print _line_notes($map_obj, $map, $line, $line_map_notes);
-        }
+    elsif ($self->line_mappings) {
+        printf("\n=head1 DESCRIPTION\n\n%s Metro Map: %s Line.\n\n", $self->map, $self->line);
+        print _prepare_line_mappings($map_obj, $self->line);
+    }
+    elsif ($self->line_notes) {
+        print _prepare_line_notes($map_obj, $self->map, $self->line);
     }
     elsif ($self->list_lines) {
         print join(",\n", sort @{$map_obj->get_lines}), "\n";
     }
+    elsif ($self->list_stations) {
+        my $station_list_table = _prepare_station_list($map_obj);
+        printf("Metro Map %s: Stations.\n\n", $self->map);
+        print $station_list_table;
+    }
     else {
-        eval { print $map_obj->get_shortest_route($start, $end), "\n"; };
+        my $route = $map_obj->get_shortest_route($self->start, $self->end);
+        $route = $route->preferred if $self->preferred;
+        if ($self->tabular) {
+            my $route_table = Text::ASCIITable->new;
+            $route_table->setCols('Station Name','Lines');
+            $route_table->alignCol('Lines','left');
+            for my $station(@{$route->nodes()}) {
+                $route_table->addRow($station->name, join(', ', @{ $station->line }));
+            }
+            printf("Metro Map %s: Route from %s to %s.\n\n", $self->map, $self->start, $self->end);
+            print $route_table;
+        } else {
+            no warnings;
+            print $route, "\n";
+        }
         if ($self->debug) {
             print "\n---------DEBUG-----------\n";
             foreach my $id (sort keys %{$map_obj->{tables}}) {
@@ -353,7 +433,7 @@ sub run {
             }
             print "-------------------------\n";
         }
-        print "$@\n" if ($@);
+        print "$@\n" if $@;
     }
 }
 
@@ -361,45 +441,33 @@ sub run {
 #
 # PRIVATE METHODS
 
-sub _prepare_mapping_notes {
+sub _prepare_line_mappings {
     my ($map, $line_name) = @_;
 
     my $map_table = Text::ASCIITable->new;
     $map_table->setCols('Station Name','Connected To');
 
-    my $stations = $map->get_stations($line_name);
-
-    my @station_names = ();
-    foreach my $station (@$stations) {
-        push @station_names, $station->name;
+    foreach my $station (map { $_->name } @{ $map->get_stations($line_name) }) {
+        $map_table->addRow($station, join(", ", @{$map->get_linked_stations($station)}));
     }
 
-    my $i = 0;
-    my $map_notes = {};
-    foreach (@station_names) {
-        my $a = $station_names[$i];
-        my $linked_stations = $map->get_linked_stations($a);
-        my $b = join(", ", @$linked_stations);
-
-        $map_table->addRow($a, $b);
-
-        _add_notes($map, $line_name, $map_notes, $a);
-
-        $i++;
-    }
-
-    return ($map_table, $map_notes);
+    return $map_table;
 }
 
-sub _line_notes {
-    my ($map, $map_name, $line_name, $line_map_notes) = @_;
+sub _prepare_line_notes {
+    my ($map, $map_name, $line_name) = @_;
+
+    my $line_map_notes = {};
+    foreach my $station (map { $_->name } @{ $map->get_stations($line_name) }) {
+        _add_notes($map, $line_name, $line_map_notes, $station);
+    }
 
     my $all_lines = $map->get_lines;
     my $line_package = {};
     foreach my $line (@$all_lines) {
-        next unless (scalar(@{$line->get_stations}));
         my $_line_name = $line->name;
         next if (uc($line_name) eq uc($_line_name));
+        next unless (scalar(@{$line->get_stations}));
         $line_package->{$_line_name} = 1;
     }
 
@@ -407,28 +475,91 @@ sub _line_notes {
     $notes   .= "=head1 NOTE\n\n";
     $notes   .= "=over 2\n";
 
-    foreach my $station (sort keys %$line_map_notes) {
-        my $i = 1;
-        my $lines = $line_map_notes->{$station};
+    my @stations = keys %$line_map_notes;
+    if ( eval { require Unicode::Collate; 1 } ) {
+        my $collator = Unicode::Collate->new(level => 1);
+        @stations = $collator->sort(@stations);
+    } else {
+        @stations = sort { lc($a) cmp lc($b) } @stations;
+    }
+
+    foreach my $station (@stations) {
+        my $delim = ' ';
+        my $lines   = $line_map_notes->{$station};
         my $_notes .= sprintf("\n=item * The station \"%s\" is also part of\n", $station);
         foreach my $line (@$lines) {
             next unless (exists $line_package->{$line});
-            if ($i == 1) {
-                $_notes .= sprintf("          L<%s Line|Map::Tube::%s::Line::%s>\n", $line, $map_name, _guess_package_name($line));
-                $i++;
-            }
-            else {
-                $_notes .= sprintf("        | L<%s Line|Map::Tube::%s::Line::%s>\n", $line, $map_name, _guess_package_name($line));
-            }
+            $_notes .= sprintf("        %s L<%s Line|Map::Tube::%s::Line::%s>\n",
+                               $delim, $line, $map_name, _guess_package_name($line));
+            $delim = '|';
         }
-        if ($i > 1) {
-            $notes .= $_notes;
-        }
+        $notes .= $_notes if $delim;
     }
 
     $notes .= "\n=back\n";
 
     return $notes;
+}
+
+sub _prepare_version_info {
+   my ($map, $map_name) = @_;
+    my $msg = "Map::Tube::CLI version $VERSION, Map::Tube version: $Map::Tube::VERSION";
+    if ($map_name) {
+        my $supported_maps  = _supported_maps();
+        my $map_module_name = $supported_maps->{uc($map_name)} // ( 'Map::Tube::' . $map_name );
+        my $version_ref     = $map_module_name . '::VERSION';
+        my $map_desc        = $map ? $map->name() // $map_name : '';
+        my $map_version;
+        {
+            no strict;
+            $map_version = ${$version_ref} // 'unknown';
+        }
+        $msg .= ", map $map_name: $map_desc version: $map_version";
+    }
+    return $msg;
+}
+
+sub _prepare_map_list {
+    my $supported_maps  = _supported_maps();
+    my %plugins = map { $_ => 1 } plugins;
+    my @map_list;
+    for my $map ( sort values %$supported_maps ) {
+        my $map_name = '(not installed)';
+        if (exists $plugins{$map}) {
+            try {
+                $map_name = $map->new->name();
+            } catch {
+                $map_name = '(not loadable)';
+            }
+        }
+        $map =~ s/^.*:://;
+        push(@map_list, [$map, $map_name]);
+    }
+
+    return \@map_list;
+}
+
+sub _prepare_station_list {
+    my ($map) = @_;
+
+    my $station_table = Text::ASCIITable->new;
+    $station_table->setCols('Station Name','Served by lines');
+    $station_table->alignCol('Served by lines','left');
+
+    my @stations = @{ $map->get_stations() };
+
+    if ( eval { require Unicode::Collate; 1 } ) {
+        my $collator = Unicode::Collate->new(level => 1);
+        @stations = $collator->sort(@stations);
+    } else {
+        @stations = sort { lc($a) cmp lc($b) } @stations;
+    }
+
+    foreach my $station (@stations) {
+      $station_table->addRow( $station->name, join(', ', @{ $station->line }));
+    }
+
+    return $station_table;
 }
 
 sub _guess_package_name {
@@ -482,9 +613,18 @@ sub _validate_param {
     my $line    = $self->line;
     my $bgcolor = $self->bgcolor;
 
+    return if $self->version || $self->list_maps;
+
+    Map::Tube::Exception::MissingMapName->throw({
+        method      => __PACKAGE__."::_validate_param",
+        message     => "ERROR: Missing Map Name.",
+        filename    => $caller[1],
+        line_number => $caller[2] })
+        unless (defined $map);
+
     my $supported_maps = _supported_maps();
     if ($self->force) {
-        $supported_maps->{uc($map)} = 'Map::Tube::'. $map;
+        $supported_maps->{uc($map)} //= 'Map::Tube::'. $map;
     }
 
     Map::Tube::Exception::FoundUnsupportedMap->throw({
@@ -521,12 +661,6 @@ sub _validate_param {
     }
 
     if ($self->line_mappings || $self->line_notes) {
-        Map::Tube::Exception::MissingLineName->throw({
-            method      => __PACKAGE__."::_validate_param",
-            message     => "ERROR: Missing Line Name.",
-            filename    => $caller[1],
-            line_number => $caller[2] })
-            unless (defined $line);
 
         Map::Tube::Exception::InvalidLineName->throw({
             method      => __PACKAGE__."::_validate_param",
@@ -539,7 +673,11 @@ sub _validate_param {
     unless (   $self->generate_map
             || $self->line_mappings
             || $self->line_notes
-            || $self->list_lines) {
+            || $self->list_lines
+            || $self->list_stations) {
+
+        # warn "--line option will be ignored" if defined $line;     # *** Should we warn if the --line option has been used for no good? ***
+
         Map::Tube::Exception::MissingStationName->throw({
             method      => __PACKAGE__."::_validate_param",
             message     => "ERROR: Missing Station Name [start].",
@@ -568,6 +706,7 @@ sub _validate_param {
             line_number => $caller[2] })
             unless defined $self->{maps}->{uc($map)}->get_node_by_name($end);
     }
+
 }
 
 sub _clean_path {
@@ -674,8 +813,7 @@ L<https://github.com/manwar/Map-Tube-CLI>
 =head1 BUGS
 
 Please report any bugs or feature requests through the web interface at L<https://github.com/manwar/Map-Tube-CLI/issues>.
-I will  be notified and then you'll automatically be notified of progress on your
-bug as I make changes.
+I will  be notified and then you'll automatically be notified of progress on your bug as I make changes.
 
 =head1 SUPPORT
 

--- a/lib/Map/Tube/CLI/Option.pm
+++ b/lib/Map/Tube/CLI/Option.pm
@@ -1,7 +1,11 @@
 package Map::Tube::CLI::Option;
 
-$Map::Tube::CLI::Option::VERSION   = '0.84';
-$Map::Tube::CLI::Option::AUTHORITY = 'cpan:MANWAR';
+use strict;
+use warnings;
+use version;
+
+our $VERSION   = qv('v0.850.0');
+our $AUTHORITY = 'cpan:MANWAR';
 
 =head1 NAME
 
@@ -9,7 +13,7 @@ Map::Tube::CLI::Option - Option as Moo Role for Map::Tube::CLI.
 
 =head1 VERSION
 
-Version 0.84
+Version v0.850.0
 
 =cut
 
@@ -23,18 +27,22 @@ use Types::Standard -all;
 use MooX::Options;
 
 has maps             => (is => 'rw');
-option map           => (is => 'ro', order => 1,  isa => Str, format => 's', required => 1, doc => 'Map name');
-option start         => (is => 'ro', order => 2,  isa => Str, format => 's', doc => 'Start station name');
-option end           => (is => 'ro', order => 3,  isa => Str, format => 's', doc => 'End station name'  );
-option preferred     => (is => 'ro', order => 4,  doc => 'Show preferred route');
-option generate_map  => (is => 'ro', order => 5,  doc => 'Generate map as image');
-option line          => (is => 'ro', order => 6,  isa => Str, format => 's', doc => 'Line name for map'    );
-option bgcolor       => (is => 'ro', order => 7,  isa => Str, format => 's', doc => 'Map background color' );
-option line_mappings => (is => 'ro', order => 8,  doc => 'Generate line mappings');
-option line_notes    => (is => 'ro', order => 9,  doc => 'Generate line notes');
-option list_lines    => (is => 'ro', order => 10, doc => 'List lines');
-option force         => (is => 'ro', order => 11, doc => 'Force unsupported map (map name becomes case sensitive)');
-option debug         => (is => 'ro', order => 12, doc => 'Run in debug mode');
+option map           => (is => 'ro', order => 1,  isa => Str, format => 's', doc => 'Map name',                   short => 'm');
+option start         => (is => 'ro', order => 2,  isa => Str, format => 's', doc => 'Start station name',         short => 's');
+option end           => (is => 'ro', order => 3,  isa => Str, format => 's', doc => 'End station name',           short => 'e');
+option preferred     => (is => 'ro', order => 4,                             doc => 'Show preferred route',       short => 'p');
+option generate_map  => (is => 'ro', order => 5,                             doc => 'Generate map as image',      short => 'g');
+option line          => (is => 'ro', order => 6,  isa => Str, format => 's', doc => 'Line name to map',           short => 'l');
+option bgcolor       => (is => 'ro', order => 7,  isa => Str, format => 's', doc => 'Map background color',       short => 'b');
+option line_mappings => (is => 'ro', order => 8,                             doc => 'Generate line mappings as table');
+option line_notes    => (is => 'ro', order => 9,                             doc => 'Generate line notes');
+option list_maps     => (is => 'ro', order => 10,                            doc => 'List supported maps',        short => 'M');
+option list_lines    => (is => 'ro', order => 11,                            doc => 'List lines in given map',    short => 'L');
+option list_stations => (is => 'ro', order => 12,                            doc => 'List stations in given map', short => 'S');
+option tabular       => (is => 'ro', order => 13,                            doc => 'Show route as table (not as list)',                       short => 't');
+option force         => (is => 'ro', order => 14,                            doc => 'Force unsupported map (map name becomes case sensitive)', short => 'f');
+option debug         => (is => 'ro', order => 15,                            doc => 'Run in debug mode',          short => 'D');
+option version       => (is => 'ro', order => 16,                            doc => 'Show version information',   short => 'V');
 
 =head1 DESCRIPTION
 

--- a/t/01-map-tube-cli.t
+++ b/t/01-map-tube-cli.t
@@ -16,6 +16,20 @@ is(capture_stdout { Map::Tube::CLI->new({ map => 'London', start => 'Baker Stree
    "Route check"
   );
 
+is(capture_stdout { Map::Tube::CLI->new({ map => 'London', start => 'Baker Street', end => 'Euston Square', preferred => 1, tabular => 1 })->run },
+   "Metro Map London: Route from Baker Street to Euston Square.
+
+.--------------------------------------------------------------------.
+| Station Name          | Lines                                      |
++-----------------------+--------------------------------------------+
+| Baker Street          | Circle, Hammersmith and City, Metropolitan |
+| Great Portland Street | Circle, Hammersmith and City, Metropolitan |
+| Euston Square         | Circle, Hammersmith and City, Metropolitan |
+'-----------------------+--------------------------------------------'
+",
+   "Preferred route check, tabular"
+  );
+
 is(capture_stdout { Map::Tube::CLI->new({ map => 'London', list_lines => 1 })->run },
 "Bakerloo,
 Central,
@@ -43,7 +57,7 @@ Windrush
   );
 
 eval { Map::Tube::CLI->new };
-like($@, qr/Missing required arguments: map/, 'Missing map argument');
+like($@, qr/Missing Map Name/, 'Missing map argument');
 
 eval { Map::Tube::CLI->new({ map => 'X' }) };
 like($@, qr/ERROR: Unsupported Map/, 'Non-existent map');


### PR DESCRIPTION
Hi Mohammad --

As already indicated, I would like to suggest some new features to M::T::CLI which I, personally, would find useful. Maybe you can make use of at least some of them -- but I certainly don't want to give the impression that I'm pushing you into something.
All changes should be backward-compatible (if not, that would be a bug in my changes!).
Here's a list of changes (as per file Changes) with additional comments regarding my motifs:
- Updated README.
   To reflect the changes.
- Introduced short options (in addition to long options).
   I'm a lazy guy. Also, such shortcuts are widely used in the Perl world (and beyond). 
- Added option --version/-V.
   Handy for knowing what you are actually working with. Will display version numbers of M::T::CLI, M::T itself, and the current 
   map (if given by --map).
- Added option --list_maps/-M.
   Handy in order to see what is available in the world, what is available on your machine, and which present modules look 
   broken (M::T::Bielefeld being a case in question).
- Added option --list_stations/-S.
   I continuously forget which stations are available in any given map, and what the exact spelling is.
- Added option --tabular/-t.
   M::T::CLI actually uses four different output formats: one line (for routes), tables (for --line_mappings), POD-style text 
   (for --line_notes), and one item per output line with additional comma separator (for --list_lines). 
   In particular, the route output is compact but a bit difficult to read for humans. I like the tabular style. 
   I do not want to break any application that may rely on this, though; so ordinarily, output is unchanged.
   But switch --tabular will create a neat ASCII table, as an alternative.
- Require Map::Tube::Exception 3.25.
   Needed because --map is no longer a (technically) required option (i.e., when using --version or --list_maps), so this catches
   missing --map in cases where it should be present.
- Minor code optimisations.
   Little odds and ends of organically grown code simplified.
- Make some sortings Unicode-aware (if Unicode::Collate is available)
   There's a growing number of non-ASCII maps, and standard Perl sorting does not handle these well. If Unicode::Collate 
   is available, this will be used instead. Failing that, standard sort is used as a fallback -- so no breaking additional dependency.
- Updated dependencies in Makefile.PL.
   New version of M::T::Exception required; Unicode::Collate recommended (but not required).
- Handle cases of non-printable characters in route listings slightly better.
   There was an attempt in the code (using eval) to suppress errors if some output contains characters unavailable in the 
   current screen font. The result was that in this case no output at all was produced, with no explanation.
   (Try Bucharest or Tbilisi).
   I'd suggest just to switch off warnings instead (only for these very small sections!). This will create some output at least,
   although it won't look nice.
- Added test case.
   For --preferred and --tabular (at the same time).
- Updated POD.
   To reflect changes.

I think the line notes generation code could still be simplified somewhat, but I didn't want to start an all-out attack on this front :-)

I'd be glad if you could use some of these. If not, no problem at all, of course!

All the best --happy coding --